### PR TITLE
Update to MediatR v10

### DIFF
--- a/src/MediatR.Extensions.AttributedBehaviors.Tests/MediatR.Extensions.AttributedBehaviors.Tests.csproj
+++ b/src/MediatR.Extensions.AttributedBehaviors.Tests/MediatR.Extensions.AttributedBehaviors.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="9.0.0" />
+    <PackageReference Include="MediatR" Version="10.0.1" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/src/MediatR.Extensions.AttributedBehaviors/MediatR.Extensions.AttributedBehaviors.csproj
+++ b/src/MediatR.Extensions.AttributedBehaviors/MediatR.Extensions.AttributedBehaviors.csproj
@@ -4,7 +4,7 @@
 	<Authors>ITIXO</Authors>
 	<Description>MediatR extension adding ability to specify pipeline behaviors using attributes on command class.</Description>
 	<Copyright>Copyright (c) ITIXO</Copyright>
-	<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+	<TargetFrameworks>netstandard2.1</TargetFrameworks>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>
 	<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="9.0.0" />
+    <PackageReference Include="MediatR" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This commit tries to fix System.TypeLoadException in MediatR v10


System.TypeLoadException
  HResult=0x80131522
  Message=Could not load type 'MediatR.IRequest' from assembly 'MediatR, Version=10.0.0.0, Culture=neutral, PublicKeyToken=bb9a41a5e8aaa7e2'.
  Source=MediatR.Extensions.AttributedBehaviors
  StackTrace:
   at MediatR.Extensions.AttributedBehaviors.ServiceCollectionExtensions.<>c.<AddMediatRAttributedBehaviors>b__1_1(TypeInfo ti)
   at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
   at MediatR.Extensions.AttributedBehaviors.ServiceCollectionExtensions.AddMediatRAttributedBehaviors(IServiceCollection services, IEnumerable`1 assemblies)
   at MediatR.Extensions.AttributedBehaviors.ServiceCollectionExtensions.AddMediatRAttributedBehaviors(IServiceCollection services, Assembly assembly)