### PR TITLE
updated mediatr reference to v12

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ public class MyQuery : IRequest
 ```
 
 ## Changelog
+### 3.0.0
+- Updated MediatR dependency to 12.x
+- Dropped direct reference to Microsoft.Extensions.DependencyInjection.Abstractions
+- Updated tests based on breaking changes from MediatR 12.x
 
 ### 2.0.0
 - Updated MediatR dependency to 10.x

--- a/src/MediatR.Extensions.AttributedBehaviors.Tests/CustomLifetimeTests.cs
+++ b/src/MediatR.Extensions.AttributedBehaviors.Tests/CustomLifetimeTests.cs
@@ -33,7 +33,7 @@ namespace MediatR.Extensions.AttributedBehaviors.Tests
 
         public class TransientBehavior : IPipelineBehavior<Ping, Pong>
         {
-            public Task<Pong> Handle(Ping request, CancellationToken cancellationToken, RequestHandlerDelegate<Pong> next)
+            public Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, CancellationToken cancellationToken)
             {
                 return next();
             }
@@ -41,7 +41,7 @@ namespace MediatR.Extensions.AttributedBehaviors.Tests
 
         public class SingletonBehavior : IPipelineBehavior<Ping, Pong>
         {
-            public Task<Pong> Handle(Ping request, CancellationToken cancellationToken, RequestHandlerDelegate<Pong> next)
+            public Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, CancellationToken cancellationToken)
             {
                 return next();
             }
@@ -49,7 +49,7 @@ namespace MediatR.Extensions.AttributedBehaviors.Tests
         
         public class ScopedBehavior : IPipelineBehavior<Ping, Pong>
         {
-            public Task<Pong> Handle(Ping request, CancellationToken cancellationToken, RequestHandlerDelegate<Pong> next)
+            public Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, CancellationToken cancellationToken)
             {
                 return next();
             }
@@ -95,7 +95,7 @@ namespace MediatR.Extensions.AttributedBehaviors.Tests
         {
             IServiceCollection services = new ServiceCollection();
             var assembly = typeof(Ping).GetTypeInfo().Assembly;
-            services.AddMediatR(assembly);
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(assembly));
             services.AddMediatRAttributedBehaviors(assembly);
 
             var provider = services.BuildServiceProvider();

--- a/src/MediatR.Extensions.AttributedBehaviors.Tests/CustomOrderingTests.cs
+++ b/src/MediatR.Extensions.AttributedBehaviors.Tests/CustomOrderingTests.cs
@@ -45,7 +45,7 @@ namespace MediatR.Extensions.AttributedBehaviors.Tests
                 _output = output;
             }
 
-            public async Task<Pong> Handle(Ping request, CancellationToken cancellationToken, RequestHandlerDelegate<Pong> next)
+            public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, CancellationToken cancellationToken)
             {
                 _output.Messages.Add("First before");
                 var response = await next();
@@ -64,7 +64,7 @@ namespace MediatR.Extensions.AttributedBehaviors.Tests
                 _output = output;
             }
 
-            public async Task<Pong> Handle(Ping request, CancellationToken cancellationToken, RequestHandlerDelegate<Pong> next)
+            public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, CancellationToken cancellationToken)
             {
                 _output.Messages.Add("Second before");
                 var response = await next();
@@ -81,7 +81,7 @@ namespace MediatR.Extensions.AttributedBehaviors.Tests
             IServiceCollection services = new ServiceCollection();
             services.AddSingleton(output);
             var assembly = typeof(Ping).GetTypeInfo().Assembly;
-            services.AddMediatR(assembly);
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(assembly));
             services.AddMediatRAttributedBehaviors(assembly);
 
             var provider = services.BuildServiceProvider();

--- a/src/MediatR.Extensions.AttributedBehaviors.Tests/MediatR.Extensions.AttributedBehaviors.Tests.csproj
+++ b/src/MediatR.Extensions.AttributedBehaviors.Tests/MediatR.Extensions.AttributedBehaviors.Tests.csproj
@@ -7,11 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="10.0.1" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="MediatR" Version="12.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />
+    <PackageReference Include="Shouldly" Version="4.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MediatR.Extensions.AttributedBehaviors.Tests/MultipleBehaviorsTests.cs
+++ b/src/MediatR.Extensions.AttributedBehaviors.Tests/MultipleBehaviorsTests.cs
@@ -45,7 +45,7 @@ namespace MediatR.Extensions.AttributedBehaviors.Tests
                 _output = output;
             }
 
-            public async Task<Pong> Handle(Ping request, CancellationToken cancellationToken, RequestHandlerDelegate<Pong> next)
+            public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, CancellationToken cancellationToken)
             {
                 _output.Messages.Add("Outer before");
                 var response = await next();
@@ -64,7 +64,7 @@ namespace MediatR.Extensions.AttributedBehaviors.Tests
                 _output = output;
             }
 
-            public async Task<Pong> Handle(Ping request, CancellationToken cancellationToken, RequestHandlerDelegate<Pong> next)
+            public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, CancellationToken cancellationToken)
             {
                 _output.Messages.Add("Inner before");
                 var response = await next();
@@ -81,7 +81,7 @@ namespace MediatR.Extensions.AttributedBehaviors.Tests
             IServiceCollection services = new ServiceCollection();
             services.AddSingleton(output);
             var assembly = typeof(Ping).GetTypeInfo().Assembly;
-            services.AddMediatR(assembly);
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(assembly));
             services.AddMediatRAttributedBehaviors(assembly);
 
             var provider = services.BuildServiceProvider();

--- a/src/MediatR.Extensions.AttributedBehaviors.Tests/SingleBehaviorTests.cs
+++ b/src/MediatR.Extensions.AttributedBehaviors.Tests/SingleBehaviorTests.cs
@@ -45,7 +45,7 @@ namespace MediatR.Extensions.AttributedBehaviors.Tests
                 _output = output;
             }
 
-            public async Task<Pong> Handle(Ping request, CancellationToken cancellationToken, RequestHandlerDelegate<Pong> next)
+            public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, CancellationToken cancellationToken)
             {
                 _output.Messages.Add("Behavior before");
                 var response = await next();
@@ -62,7 +62,7 @@ namespace MediatR.Extensions.AttributedBehaviors.Tests
             IServiceCollection services = new ServiceCollection();
             services.AddSingleton(output);
             var assembly = typeof(Ping).GetTypeInfo().Assembly;
-            services.AddMediatR(assembly);
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(assembly));
             services.AddMediatRAttributedBehaviors(assembly);
 
             var provider = services.BuildServiceProvider();

--- a/src/MediatR.Extensions.AttributedBehaviors/MediatR.Extensions.AttributedBehaviors.csproj
+++ b/src/MediatR.Extensions.AttributedBehaviors/MediatR.Extensions.AttributedBehaviors.csproj
@@ -14,8 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="MediatR" Version="12.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Updated MediatR dependency to 12.x
- Dropped direct reference to Microsoft.Extensions.DependencyInjection.Abstractions
- Updated tests based on breaking changes from MediatR 12.x