### PR TITLE
MediatRBehaviorAttribute also targets structs

### DIFF
--- a/src/MediatR.Extensions.AttributedBehaviors/MediatRBehaviorAttribute.cs
+++ b/src/MediatR.Extensions.AttributedBehaviors/MediatRBehaviorAttribute.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 
 namespace MediatR.Extensions.AttributedBehaviors
 {
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = true)]
     public class MediatRBehaviorAttribute : Attribute
     {
         public Type BehaviorType { get; }


### PR DESCRIPTION
The intention with this PR is to allow attributed behaviors when the MediatR request happens to be a `struct`.

```csharp
[MediatRBehavior(typeof(MyFirstPipelineBehavior<MyRequest, MyReturnType>))]
public record struct MyRequest(string Id) : IRequest<MyReturnType>;
```